### PR TITLE
Allow Multiple redirection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,12 @@ int main(void){
         fflush(stdout);
         int pid = fork(); 
         if (pid == 0) {
-            RedirectionParams redirParams = shell.PostTokeniseProcessing(tokens);
+            RedirectionParams redirParams = {0};
+            RedirErr err = shell.PostTokeniseProcessing(redirParams, tokens);
+            if (err!=RedirErrNone){
+                perror("Wrong Redirection");
+                continue;
+            }
             shell.HandleRedirection(redirParams);
             shell.ExecuteProgram(redirParams.cmd);
             perror("unable to execute");

--- a/src/redirection.h
+++ b/src/redirection.h
@@ -7,6 +7,11 @@
 #define REDIRECTION_H
 
 #include <vector>
+enum RedirErr{
+    RedirErrNone = 0,
+    RedirErrWrongOrder = 1,
+};
+
 enum RedirectionType
 {
     RedirNone = 0,   

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -315,8 +315,7 @@ void Shell::setCmdEnd(RedirectionParams& redirParams, int index){
  * \brief Check for Redirection and split out command
  * @param input vector of strings
  */
-RedirectionParams Shell::PostTokeniseProcessing(vector<string>& cmd){
-    RedirectionParams redirParams = {0};
+RedirErr Shell::PostTokeniseProcessing(RedirectionParams& redirParams, vector<string>& cmd){
     redirParams.cmdEnd = cmd.size();
     ofstream outputFile;
     ifstream inputFile;
@@ -342,9 +341,12 @@ RedirectionParams Shell::PostTokeniseProcessing(vector<string>& cmd){
                 redirParams.infilename = cmd[redirParams.inputFileIndex];
         } 
     }
+    if ((redirParams.outputFileIndex != 0) && (redirParams.inputFileIndex != 0) &&(redirParams.outputFileIndex <= redirParams.inputFileIndex)){
+        return RedirErrWrongOrder; 
+    }
     vector<string> inputCmd;
     redirParams.cmd.assign(cmd.begin()+redirParams.cmdStart, cmd.begin()+redirParams.cmdEnd);
-    return redirParams; 
+    return RedirErrNone; 
 }
 
 /**

--- a/src/shell.h
+++ b/src/shell.h
@@ -90,7 +90,7 @@ public:
     void PutTerminalInPerCharMode(void);
     void PutTerminalBackInNormalMode(void);
     vector<string> Tokenise(string s, char delimiter);
-    RedirectionParams PostTokeniseProcessing(vector<string>& cmd);
+    RedirErr PostTokeniseProcessing(RedirectionParams& redirParams, vector<string>& cmd);
     void HandleRedirection(RedirectionParams& redirParams);
     void printTokens(const vector<string> &input, ostream& ofs);   
 };


### PR DESCRIPTION
- Allow commands like 
```
cat < cmd.txt > test.txt
```
- Add unit tests for multiple redirection
- Refactor to have PostTokeniseProcessing return an error that allows to handle invalid redirection
- Unit tests updated 